### PR TITLE
Typo and none check

### DIFF
--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -296,7 +296,7 @@ def create_template(tool: str):
                 template += f"\n    if not isinstance({arg_name}, type(None)):\n    "
                 template += f"    cfl.writecfl(\'{arg_name}\', {arg_name})\n    "
             else:
-                template += f"\n    if " + arg_name + " != None:\n    "
+                template += f"\n    if " + arg_name + " is not None:\n    "
             if kwarg['is_long_opt']:
                 template += f"    flag_str += f'--{flag} "
             elif kwarg['type'] == 'array':

--- a/demos/Non-Cartesian MRI Using BART.ipynb
+++ b/demos/Non-Cartesian MRI Using BART.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trad_rad2 = bart.scale(traj_rad, 0.6)"
+    "traj_rad2 = bart.scale(traj_rad, 0.6)"
    ]
   },
   {


### PR DESCRIPTION
Hi Max,

I took a look at your (really great!) notebooks and was surprised by the quality of the result in the Non-Cartesian notebook, especially compared to the [Matlab example](https://mrirecon.github.io/bart/examples.html#21) [(image here)](https://mrirecon.github.io/bart/imgs/examples_13.png). I found one typo, where you assign to `trad_rad2` instead of overwriting `traj_rad2`. Fixing this gets rid of the ugly part at the bottom of the phantom.


Additionally, I think that `is not None` is more common in the python community. But feel free to regard this if you don't like it.


All the best, 
Christian